### PR TITLE
Allow middle clicking to close tabs

### DIFF
--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -6,6 +6,7 @@
           :key="file.id"
           :class="[{ active: file.id === (activeFile? activeFile.id: null) }]"
           @click="setActiveFile({ editor, id: file.id })"
+          @click.middle="closeFile({ editor, id: file.id })"
         >
           <span>{{ file.name }}</span>
           <XIcon


### PR DESCRIPTION
Just like in most popular text editors and web browsers, this change allows middle mouse clicking to close tabs.