### PR TITLE
Fix repo clone instructions typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Built with Vue.js, Dexie and CodeMirror
 
 ## Project setup
 ```
-git clone https://github.com/haxzie/hspace
-cd hspace
+git clone https://github.com/haxzie/snipp.in snippin
+cd snippin
 npm install
 ```
 


### PR DESCRIPTION
Fixed repo clone instructions typo where it said clone a repo named hspace