### PR TITLE
Copy and download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5105,6 +5105,11 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "core-js": "^3.6.5",
     "dexie": "^3.0.1",
+    "file-saver": "^2.0.5",
     "lodash": "^4.17.19",
     "simplebar-vue": "^1.5.1",
     "uuid": "^8.2.0",

--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -35,9 +35,9 @@
           <div class="option-item" @click="downloadFile">
             <download-icon size="18" class="icon" />Download File
           </div>
-          <div class="option-item">
+          <!--<div class="option-item">
             <copy-icon size="18" class="icon" />Duplicate File
-          </div>
+          </div>-->
           <div class="option-item" @click="copyFileContents">
             <clipboard-icon size="18" class="icon" />Copy contents
           </div>

--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -32,7 +32,7 @@
           <div class="option-item" @click="openRenameMode">
             <edit3-icon size="18" class="icon" />Rename
           </div>
-          <div class="option-item">
+          <div class="option-item" @click="downloadFile">
             <download-icon size="18" class="icon" />Download File
           </div>
           <div class="option-item">
@@ -63,6 +63,7 @@ import {
 } from "vue-feather-icons";
 import { mapActions } from "vuex";
 import { SlideYUpTransition } from "vue2-transitions";
+import { saveAs } from "file-saver";
 
 export default {
   components: {
@@ -112,6 +113,12 @@ export default {
     },
     copyFileContents() {
       navigator.clipboard.writeText(this.file.contents);
+    },
+    downloadFile() {
+      const fileBlob = new Blob([this.file.contents], {
+        type: "text/plain;charset=utf-8",
+      });
+      saveAs(fileBlob, this.file.name);
     },
   },
   watch: {

--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -32,15 +32,15 @@
           <div class="option-item" @click="openRenameMode">
             <edit3-icon size="18" class="icon" />Rename
           </div>
-          <!-- <div class="option-item">
+          <div class="option-item">
             <download-icon size="18" class="icon" />Download File
           </div>
           <div class="option-item">
             <copy-icon size="18" class="icon" />Duplicate File
           </div>
-          <div class="option-item">
+          <div class="option-item" @click="copyFileContents">
             <clipboard-icon size="18" class="icon" />Copy contents
-          </div> -->
+          </div>
           <div class="option-item" @click="deleteCurrentFile">
             <trash2-icon size="18" class="icon" />Delete File
           </div>
@@ -110,6 +110,9 @@ export default {
       this.showContextMenu = !this.showContextMenu;
       this.deleteFile({ id: this.file.id });
     },
+    copyFileContents() {
+      navigator.clipboard.writeText(this.file.contents);
+    },
   },
   watch: {
     readonly(value) {
@@ -125,7 +128,7 @@ export default {
         if (this.file.editable) {
           setTimeout(() => {
             this.$refs.input.focus();
-          }, 200)
+          }, 200);
         }
       },
     },


### PR DESCRIPTION
Resolves #1 

- I had to use [file-saver](https://www.npmjs.com/package/file-saver) as pointed out by @FlorianWoelki. I used this as it has better browser support and is relatively a lightweight library. I believe the same can be done by using the <a> tag with the download attribute natively.
- I haven't added the shortcuts yet as i wasn't sure of the key map style, do you think `Alt + s` is a good choice for download file and `Alt + a` for copy contents?