### PR TITLE
Fix context menu visibility on hovering something out of the context menu

### DIFF
--- a/src/components/DirectoryItem.vue
+++ b/src/components/DirectoryItem.vue
@@ -6,7 +6,7 @@
     @dragover.prevent.stop="handleDragOver"
     @dragenter.prevent
   >
-    <div :class="['file-item', { active: isActive }]">
+    <div :class="['file-item', { active: isActive || showContextMenu }]">
       <div
         class="clickable-area"
         @click="toggleShowChildren"
@@ -30,6 +30,7 @@
       <div class="context-menu">
         <MoreVerticalIcon
           class="trigger-icon no-margin"
+          :style="showContextMenu ? 'visibility: visible' : null"
           size="18"
           @click="toggleContextMenu"
         />
@@ -277,7 +278,6 @@ export default {
   }
 
   .context-menu {
-    display: none;
     align-items: center;
     justify-content: center;
     align-items: center;
@@ -285,6 +285,7 @@ export default {
     transition: 0.3s all ease-in-out;
 
     .trigger-icon {
+      display: block;
       visibility: hidden;
       padding: 5px;
       border-radius: 5px;

--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['file-item', { active: isActive }]">
+  <div :class="['file-item', { active: isActive || showContextMenu }]">
     <div
       class="clickable-area"
       @click="openFile({ id: file.id })"
@@ -22,6 +22,7 @@
     <div class="context-menu">
       <MoreVerticalIcon
         class="trigger-icon"
+        :style="showContextMenu ? 'visibility: visible' : null"
         size="18"
         @click="toggleContextMenu"
       />
@@ -202,7 +203,6 @@ export default {
   }
 
   .context-menu {
-    display: none;
     align-items: center;
     justify-content: center;
     align-items: center;
@@ -210,6 +210,7 @@ export default {
     transition: 0.3s all ease-in-out;
 
     .trigger-icon {
+      display: block;
       visibility: hidden;
       padding: 5px;
       border-radius: 5px;


### PR DESCRIPTION
Hey there!

Issue: If you open the context menu and do not hover the context menu or the file, the context menu will vanish unexpectedly.

Fix: I've fixed the issue by always showing the context menu whenever the user clicks on the vertical dots icon and hovers something else.