### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+         docker build . --file Dockerfile --tag snipp-docker:$(date +%s)
+
+

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,6 +1,7 @@
 name: Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
@@ -15,6 +16,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: |
-         docker build . --file Dockerfile --tag snipp-docker:$(date +%s)
+         docker build . --file Dockerfile --tag snipp:$(date +%s)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:lts-alpine as build-stage
+
+# Create app directory
+WORKDIR /app
+
+COPY . /app
+
+# Install app dependencies
+RUN npm install
+
+# build app for production with minification
+RUN npm run build
+
+# Bundle app source
+COPY . .
+
+
+# production stage
+FROM nginx:stable-alpine as production-stage
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+
+
+
+


### PR DESCRIPTION
I liked this project and wanted to host an instance on my server. I wanted to dockerize the app to make it easier to manage. I think that adding `Dockefile` and an GitHub action `CI` to test would be a suitable for people who want to build docker image. 

Also, if @haxzie wants to add official docker image it can be done easily, and I could help make `CI` to build the image and push it on official docker hub image.