### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine as build-stage
+FROM node:12-alpine as build-stage
 
 # Create app directory
 WORKDIR /app


### PR DESCRIPTION
node-sass requirements changed and now build fails because of no longer supported node version. 

The solution is to change the base image to a compatible one.