### PR TITLE
Fix docker container start permission.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ COPY . .
 FROM nginx:stable-alpine as production-stage
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
-
-
-
-
+COPY entrypoint.sh /
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Starting Nginx"
+nginx -g 'daemon off;'


### PR DESCRIPTION
This PR fixes #86 

The logic of `nginx` image (used as base) for starting containers changed. So I followed and fixed the problem. It is tested to be fully working now. Nothing about docs need to be changed.  